### PR TITLE
Explicitly Disable Paperclip Attachment Validation

### DIFF
--- a/app/models/pageflow/chart/scraped_site.rb
+++ b/app/models/pageflow/chart/scraped_site.rb
@@ -6,6 +6,11 @@ module Pageflow
       has_attached_file :html_file, Chart.config.paperclip_options(extension: 'html')
       has_attached_file :csv_file, Chart.config.paperclip_options(basename: 'data', extension: 'csv')
 
+      do_not_validate_attachment_file_type(:javascript_file)
+      do_not_validate_attachment_file_type(:stylesheet_file)
+      do_not_validate_attachment_file_type(:html_file)
+      do_not_validate_attachment_file_type(:csv_file)
+
       state_machine initial: 'unprocessed' do
         extend StateMachineJob::Macro
 

--- a/chart.gemspec
+++ b/chart.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "pageflow", "~> 0.7"
   spec.add_runtime_dependency "nokogiri"
-  spec.add_runtime_dependency "paperclip"
+  spec.add_runtime_dependency "paperclip", "~> 4.2"
   spec.add_runtime_dependency "state_machine"
   spec.add_runtime_dependency "state_machine_job"
   spec.add_runtime_dependency 'i18n-js'


### PR DESCRIPTION
Required since Pageflow now depends on Paperclip 4.2.