### PR TITLE
Remove Executables from Gemspec

### DIFF
--- a/chart.gemspec
+++ b/chart.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Reporting binstubs as gem executables leads to Bundler error messages.