### PR TITLE
Manually Pass Content Types for Scraped Files to S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gem 'activeadmin', :git => 'https://github.com/codevise/active_admin.git', :bran
 gem 'ransack'
 gem 'inherited_resources', '1.4.1'
 gem 'formtastic', '2.3.0.rc2'
-
+gem 'state_machine', git: 'https://github.com/codevise/state_machine.git'

--- a/lib/pageflow/chart/configuration.rb
+++ b/lib/pageflow/chart/configuration.rb
@@ -55,9 +55,23 @@ module Pageflow
 
       def default_paperclip_path_options(options)
         {
-          path: File.join(paperclip_base_path, ":class/:id_partition/#{options.fetch(:basename, 'all')}.#{options.fetch(:extension)}")
+          path: File.join(paperclip_base_path, ":class/:id_partition/#{options.fetch(:basename, 'all')}.#{options.fetch(:extension)}"),
+          s3_headers: paperclip_s3_headers(options)
         }
       end
+
+      def paperclip_s3_headers(options)
+        {
+          'Content-Type' => CONTENT_TYPE_MAPPING[options.fetch(:extension)]
+        }
+      end
+
+      CONTENT_TYPE_MAPPING = {
+        'css' => 'text/css',
+        'js' => 'application/javascript',
+        'html' => 'text/html',
+        'csv' => 'text/plain'
+      }
     end
   end
 end

--- a/spec/pageflow/chart/configuration_spec.rb
+++ b/spec/pageflow/chart/configuration_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+module Pageflow
+  module Chart
+    describe Configuration do
+      describe 'paperclip_options' do
+        it 'returns hash with path option for file with given extension' do
+          configuration = Configuration.new
+
+          result = configuration.paperclip_options(extension: 'js')
+
+          expect(result[:path]).to eq(':host/:class/:id_partition/all.js')
+        end
+
+        it 'allows to override basename of path option' do
+          configuration = Configuration.new
+
+          result = configuration.paperclip_options(basename: 'some', extension: 'js')
+
+          expect(result[:path]).to eq(':host/:class/:id_partition/some.js')
+        end
+
+        it 'uses paperclip_base_path as prefix' do
+          configuration = Configuration.new
+          configuration.paperclip_base_path = 'main'
+
+          result = configuration.paperclip_options(basename: 'some', extension: 'js')
+
+          expect(result[:path]).to eq('main/:class/:id_partition/some.js')
+        end
+
+        it 'returns hash with s3_headers option with matching content type for js' do
+          configuration = Configuration.new
+
+          result = configuration.paperclip_options(extension: 'js')
+
+          expect(result[:s3_headers]['Content-Type']).to eq('application/javascript')
+        end
+
+        it 'returns hash with s3_headers option with matching content type for css' do
+          configuration = Configuration.new
+
+          result = configuration.paperclip_options(extension: 'css')
+
+          expect(result[:s3_headers]['Content-Type']).to eq('text/css')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Paperclip does not reliably detect content types of css and javascript
files. Browsers then ignore the css for charts.