### PR TITLE
Add new Datawrapper Host to Supported Hosts

### DIFF
--- a/app/views/pageflow/chart/page_type.json.jbuilder
+++ b/app/views/pageflow/chart/page_type.json.jbuilder
@@ -1,2 +1,2 @@
 json.key_format! camelize: :lower
-json.supported_hosts Pageflow::Chart.config.supported_hosts
+json.supported_hosts Pageflow::Chart.config.supported_hosts.uniq

--- a/lib/pageflow/chart/configuration.rb
+++ b/lib/pageflow/chart/configuration.rb
@@ -41,7 +41,7 @@ module Pageflow
         @paperclip_s3_default_options = {}
         @paperclip_base_path = ':host'
         @scraped_sites_root_url = nil
-        @supported_hosts = ['http://cf.datawrapper.de']
+        @supported_hosts = ['http://cf.datawrapper.de', 'http://datawrapper.dwcdn.de']
       end
 
       # @api private


### PR DESCRIPTION
Datawrapper changed its URL scheme. Make list of hosts unique to prevent displaying duplicates if the entry has already been added manually in the host application.