### PR TITLE
Allo configuring themes with transparent background

### DIFF
--- a/app/assets/stylesheets/pageflow/chart/transparent_background.css.erb
+++ b/app/assets/stylesheets/pageflow/chart/transparent_background.css.erb
@@ -1,0 +1,7 @@
+<%=
+  Pageflow::Chart.config.datawrapper_themes_with_transparent_background_support.map do |name|
+    "body.theme-#{name}"
+  end.join(',')
+%> {
+  background-color: rgba(0, 0, 0, 0) !important;
+}

--- a/app/assets/stylesheets/pageflow/chart/transparent_background.scss
+++ b/app/assets/stylesheets/pageflow/chart/transparent_background.scss
@@ -1,3 +1,0 @@
-body.theme-pageflow {
-  background-color: rgba(0, 0, 0, 0) !important;
-}

--- a/lib/pageflow/chart/configuration.rb
+++ b/lib/pageflow/chart/configuration.rb
@@ -42,6 +42,16 @@ module Pageflow
       # @return [Boolean]
       attr_accessor :use_custom_theme
 
+      # List of datawrapper theme names for which an additional css
+      # rule shall be injected to make the background
+      # transparent. This is only recommended for themes with dark
+      # backgrounds. By default, this is only done for the `pageflow`
+      # theme.
+      #
+      # @since edge
+      # @return [Array<String>]
+      attr_reader :datawrapper_themes_with_transparent_background_support
+
       def initialize
         @scraper_options = {
           head_script_blacklist: [/piwik/],
@@ -57,6 +67,7 @@ module Pageflow
           'http://datawrapper.dwcdn.net'
         ]
         @use_custom_theme = false
+        @datawrapper_themes_with_transparent_background_support = ['pageflow']
       end
 
       # @api private


### PR DESCRIPTION
If a theme has a dark background, we can insert a CSS rule to make the background transparent. That gives Pageflow the opportunity to determine the exact color.