### PR TITLE
Do not abort js execution on exception in chart

### DIFF
--- a/app/jobs/pageflow/chart/scrape_site_job.rb
+++ b/app/jobs/pageflow/chart/scrape_site_job.rb
@@ -19,12 +19,17 @@ module Pageflow
             content_type: 'text/html'
           )
 
-          downloader.load_all(scraper.javascript_urls, extension: '.js', separator: "\n;") do |file|
-            scraped_site.javascript_file = file
+          downloader.load_all(scraper.javascript_urls,
+                              extension: '.js',
+                              before_each: begin_try_catch,
+                              after_each: end_try_catch) do |javascript_file|
+            scraped_site.javascript_file = javascript_file
           end
 
-          downloader.load_all(scraper.stylesheet_urls, extension: '.css', separator: "\n;") do |file|
-            scraped_site.stylesheet_file = file
+          downloader.load_all(scraper.stylesheet_urls,
+                              extension: '.css',
+                              separator: "\n;") do |stylesheet_file|
+            scraped_site.stylesheet_file = stylesheet_file
           end
         end
 
@@ -38,6 +43,14 @@ module Pageflow
       def self.perform_with_result(scraped_site, options = {})
         # This is were the downloader passed to `initialize` is created.
         new(Downloader.new(base_url: scraped_site.url)).perform(scraped_site)
+      end
+
+      def begin_try_catch
+        ";try {\n"
+      end
+
+      def end_try_catch
+        "\n} catch(e) { console.log('Datawrapper raised: ' + (e.message || e)); }\n"
       end
     end
 

--- a/lib/pageflow/chart/downloader.rb
+++ b/lib/pageflow/chart/downloader.rb
@@ -26,12 +26,15 @@ module Pageflow
 
         begin
           urls.map do |url|
+            file.write(options[:before_each]) if options.key?(:before_each)
+
             load(url) do |source|
               while data = source.read(16 * 1024)
                 file.write(data)
               end
             end
 
+            file.write(options[:after_each]) if options.key?(:after_each)
             file.write(options.fetch(:separator, "\n"))
           end
 

--- a/spec/pageflow/chart/downloader_spec.rb
+++ b/spec/pageflow/chart/downloader_spec.rb
@@ -84,6 +84,22 @@ module Pageflow
 
           expect(result).to eq("aaa;bbb;")
         end
+
+        it 'allows to wrap file contents' do
+          downloader = Downloader.new
+          result = ''
+
+          stub_request(:get, "http://example.com/a").to_return(status: 200, body: 'aaa')
+          stub_request(:get, "http://example.com/b").to_return(status: 200, body: 'bbb')
+
+          downloader.load_all(['http://example.com/a', 'http://example.com/b'],
+                              before_each: 'try {',
+                              after_each: '} catch(e) {}') do |io|
+            result = io.read
+          end
+
+          expect(result).to eq("try {aaa} catch(e) {}\ntry {bbb} catch(e) {}\n")
+        end
       end
     end
   end


### PR DESCRIPTION
Since the scraped site concatenates all js files, an exception causes
immediate halt of js inside the chart. The original chart with
separate js files continues to execute the next file though.

Wrap each file in try/catch block and only log errors to debug
console.