### PR TITLE
leave asset_path functionality default

### DIFF
--- a/app/assets/javascripts/pageflow/chart/asset_urls.js.erb
+++ b/app/assets/javascripts/pageflow/chart/asset_urls.js.erb
@@ -1,4 +1,4 @@
 pageflow.chart.assetUrls = {
-  customStylesheet: '<%= asset_path('pageflow/chart/custom.css', :protocol => 'http') %>',
-  transparentBackgroundStylesheet: '<%= asset_path('pageflow/chart/transparent_background.css', :protocol => 'http') %>'
+  customStylesheet: '<%= asset_path("pageflow/chart/custom.css") %>',
+  transparentBackgroundStylesheet: '<%= asset_path("pageflow/chart/transparent_background.css") %>'
 };


### PR DESCRIPTION
won't **force** https into http anymore.
it would trigger a warning in the console.