### PR TITLE
implement the needed proxy inside the engine

### DIFF
--- a/app/controllers/pageflow/chart/proxies_controller.rb
+++ b/app/controllers/pageflow/chart/proxies_controller.rb
@@ -1,0 +1,24 @@
+require "open-uri"
+
+module Pageflow
+  module Chart
+    class ProxiesController < Chart::ApplicationController
+       def s3
+         url = [
+           ENV.fetch('S3_PROTOCOL'),
+           "://",
+           ENV.fetch('S3_HOST_ALIAS'),
+           "/",
+           ENV.fetch('S3_BUCKET'),
+           "/",
+           params[:path]
+         ].join
+
+         response = Rails.cache.fetch(params[:path], expires_in: 1.hour) do
+           Net::HTTP.get_response( URI.parse(url).read )
+         end
+         send_data response.body, type: response.content_type, disposition: "inline"
+       end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Pageflow::Chart::Engine.routes.draw do
+  get 'proxy/*path', to: 'proxies#s3', format: false
   resources :scraped_sites, only: [:create, :show]
 end


### PR DESCRIPTION
won't have to deal with httpserver config, and now the proxy also works
in development and test environments.