### PR TITLE
Update Datawrapper scraping

### DIFF
--- a/lib/pageflow/chart/scraper.rb
+++ b/lib/pageflow/chart/scraper.rb
@@ -67,12 +67,13 @@ module Pageflow
       end
 
       def combine_script_tags_in_head
-        script_tags_in_head.each(&:remove)
+        script_src_tags_in_head.each(&:remove)
 
-        all_script_tag = Nokogiri::XML::Node.new('script', document)
-        all_script_tag[:src] = 'all.js'
-        all_script_tag[:type] = 'text/javascript'
-        document.at_css('head') << all_script_tag
+        all_script_src_tag = Nokogiri::XML::Node.new('script', document)
+        all_script_src_tag[:src] = 'all.js'
+        all_script_src_tag[:type] = 'text/javascript'
+        document.at_css('head').children.first
+                .add_previous_sibling(all_script_src_tag)
       end
 
       def combine_css_link_tags
@@ -86,14 +87,14 @@ module Pageflow
       end
 
       def filtered_script_tags_in_head
-        script_tags_in_head.reject do |tag|
+        script_src_tags_in_head.reject do |tag|
           options.fetch(:head_script_blacklist, []).any? do |regexp|
             tag[:src] =~ regexp
           end
         end
       end
 
-      def script_tags_in_head
+      def script_src_tags_in_head
         document.css('head script[src]')
       end
 

--- a/spec/pageflow/chart/scraper_spec.rb
+++ b/spec/pageflow/chart/scraper_spec.rb
@@ -8,7 +8,9 @@ module Pageflow
           html = <<-HTML
             <!DOCTYPE html>
             <html>
-              <head></head>
+              <head>
+                <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+              </head>
               <body>contents</body>
             </html>
           HTML
@@ -57,7 +59,9 @@ module Pageflow
           html = <<-HTML
             <!DOCTYPE html>
             <html>
-              <head></head>
+              <head>
+                <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+              </head>
               <body>
                 <script id="good">window.ok = true;</script>
                 <script id="bad">alert();</script>
@@ -74,7 +78,9 @@ module Pageflow
           html = <<-HTML
             <!DOCTYPE html>
             <html>
-              <head></head>
+              <head>
+                <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+              </head>
               <body>
                 <div id="bad" class="noscript"></div>
                 <div id="good"></div>


### PR DESCRIPTION
`pageflow-chart` will now add `all.js` from the first child of
<head>. This re-ordering is beneficial because Datawrapper currently
includes the Pageflow theme from inline JS. `pageflow-chart`, until
before this commit, assumes that Datawrapper always includes the
Pageflow theme from an external `src`.