### PR TITLE
Follow redirects from refresh meta tags

### DIFF
--- a/app/jobs/pageflow/chart/scrape_site_job.rb
+++ b/app/jobs/pageflow/chart/scrape_site_job.rb
@@ -11,7 +11,7 @@ module Pageflow
       end
 
       def perform(scraped_site)
-        downloader.load(scraped_site.url) do |file|
+        downloader.load_following_refresh_tags(scraped_site.url) do |file|
           scraper = Scraper.new(file.read, Chart.config.scraper_options)
           scraped_site.html_file = StringIOWithContentType.new(
             scraper.html,
@@ -42,7 +42,8 @@ module Pageflow
 
       def self.perform_with_result(scraped_site, options = {})
         # This is were the downloader passed to `initialize` is created.
-        new(Downloader.new(base_url: scraped_site.url)).perform(scraped_site)
+        new(RefreshTagFollowingDownloader.new(Downloader.new(base_url: scraped_site.url)))
+          .perform(scraped_site)
       end
 
       def begin_try_catch

--- a/lib/pageflow/chart/refresh_tag_following_downloader.rb
+++ b/lib/pageflow/chart/refresh_tag_following_downloader.rb
@@ -1,0 +1,62 @@
+require 'nokogiri'
+require 'uri'
+
+module Pageflow
+  module Chart
+    class RefreshTagFollowingDownloader < SimpleDelegator
+      MAX_REDIRECT_COUNT = 3
+
+      class TooManyRedirects < StandardError; end
+      class NoUrlInRefreshMetaTag < StandardError; end
+
+      def load_following_refresh_tags(url, redirect_count = 0, &block)
+        load(url) do |file|
+          if (redirect_url = find_refresh_meta_tag_url(file.read))
+            if redirect_count >= MAX_REDIRECT_COUNT
+              raise TooManyRedirects, 'Too many redirects via refresh meta tags.'
+            end
+
+            redirect_url = ensure_absolute(redirect_url, url)
+            return load_following_refresh_tags(redirect_url, redirect_count + 1, &block)
+          end
+
+          file.rewind
+          yield file if block_given?
+        end
+      end
+
+      private
+
+      def find_refresh_meta_tag_url(html)
+        tag = find_refresh_meta_tag(html)
+
+        extract_redirect_url(tag) if tag
+      end
+
+      def find_refresh_meta_tag(html)
+        document = Nokogiri::HTML(html)
+        document.at_css('head meta[http-equiv="REFRESH"]')
+      end
+
+      def extract_redirect_url(tag)
+        if tag[:content] && tag[:content] =~ /url=/
+          tag[:content].split('url=').last
+        else
+          raise NoUrlInRefreshMetaTag, "Could not extract url from #{tag}."
+        end
+      end
+
+      def ensure_absolute(url, context_url)
+        uri = URI(url)
+        context_uri = URI(context_url)
+
+        [
+          uri.scheme || context_uri.scheme,
+          '://',
+          uri.host || context_uri.host,
+          uri.path
+        ].join('')
+      end
+    end
+  end
+end

--- a/spec/jobs/pageflow/chart/scrape_site_job_spec.rb
+++ b/spec/jobs/pageflow/chart/scrape_site_job_spec.rb
@@ -5,14 +5,14 @@ module Pageflow
     describe ScrapeSiteJob do
       describe '#perform' do
         it 'scrapes html' do
-          scraper = double("Scraper", html: '<html>rewritten</html>')
-          downloader = double("Downloader", load: '<html>original</html>')
+          scraper = double('Scraper', html: '<html>rewritten</html>')
+          downloader = double('Downloader', load: '<html>original</html>')
           job = ScrapeSiteJob.new(downloader)
           scraped_site = create(:scraped_site, url: 'http://example.com')
 
           allow(Scraper).to receive(:new).and_return(scraper)
 
-          expect(downloader).to receive(:load).with('http://example.com')
+          expect(downloader).to receive(:load_following_refresh_tags).with('http://example.com')
 
           job.perform(scraped_site)
         end

--- a/spec/pageflow/chart/refresh_tag_following_downloader_spec.rb
+++ b/spec/pageflow/chart/refresh_tag_following_downloader_spec.rb
@@ -1,0 +1,178 @@
+require 'spec_helper'
+
+module Pageflow
+  module Chart
+    describe RefreshTagFollowingDownloader do
+      describe '#load_following_refresh_tags' do
+        it 'delegates to downloader if no refresh meta tag is found' do
+          downloader = double(Downloader)
+          refresh_tag_following_downloader = RefreshTagFollowingDownloader.new(downloader)
+
+          original_url = 'http://datawrapper.dwcdn.net/HPKfl/2/'
+
+          chart_html = <<-HTML
+            <html><head><title>A chart</title></head></html>
+          HTML
+
+          result = ''
+
+          allow(downloader).to receive(:load)
+            .with(original_url)
+            .and_yield(StringIO.new(chart_html))
+
+          refresh_tag_following_downloader.load_following_refresh_tags(original_url) do |file|
+            result = file.read
+          end
+
+          expect(result).to eq(chart_html)
+        end
+
+        it 'looks for refresh meta tags and loads their url instead' do
+          downloader = double(Downloader)
+          refresh_tag_following_downloader = RefreshTagFollowingDownloader.new(downloader)
+
+          original_url = 'http://datawrapper.dwcdn.net/HPKfl/2/'
+          target_url = 'http://other.dwcdn.net/HPKfl/5/'
+
+          redirect_html = <<-HTML
+            <html><head><meta http-equiv="REFRESH" content="0; url=http://other.dwcdn.net/HPKfl/5/"></head></html>
+          HTML
+          chart_html = <<-HTML
+            <html><head><title>A chart</title></head></html>
+          HTML
+
+          result = ''
+
+          allow(downloader).to receive(:load)
+            .with(original_url)
+            .and_yield(StringIO.new(redirect_html))
+
+          allow(downloader).to receive(:load)
+            .with(target_url)
+            .and_yield(StringIO.new(chart_html))
+
+          refresh_tag_following_downloader.load_following_refresh_tags(original_url) do |file|
+            result = file.read
+          end
+
+          expect(result).to eq(chart_html)
+        end
+
+        it 'supports schema relative urls' do
+          downloader = double(Downloader)
+          refresh_tag_following_downloader = RefreshTagFollowingDownloader.new(downloader)
+
+          original_url = 'http://datawrapper.dwcdn.net/HPKfl/2/'
+          target_url = 'http://other.dwcdn.net/HPKfl/5/'
+
+          redirect_html = <<-HTML
+            <html><head><meta http-equiv="REFRESH" content="0; url=//other.dwcdn.net/HPKfl/5/"></head></html>
+          HTML
+          chart_html = <<-HTML
+            <html><head><title>A chart</title></head></html>
+          HTML
+
+          result = ''
+
+          allow(downloader).to receive(:load)
+            .with(original_url)
+            .and_yield(StringIO.new(redirect_html))
+
+          allow(downloader).to receive(:load)
+            .with(target_url)
+            .and_yield(StringIO.new(chart_html))
+
+          refresh_tag_following_downloader.load_following_refresh_tags(original_url) do |file|
+            result = file.read
+          end
+
+          expect(result).to eq(chart_html)
+        end
+
+        it 'supports relative urls' do
+          downloader = double(Downloader)
+          refresh_tag_following_downloader = RefreshTagFollowingDownloader.new(downloader)
+
+          original_url = 'http://datawrapper.dwcdn.net/HPKfl/2/'
+          target_url = 'http://datawrapper.dwcdn.net/HPKfl/5/'
+
+          redirect_html = <<-HTML
+            <html><head><meta http-equiv="REFRESH" content="0; url=/HPKfl/5/"></head></html>
+          HTML
+          chart_html = <<-HTML
+            <html><head><title>A chart</title></head></html>
+          HTML
+
+          result = ''
+
+          allow(downloader).to receive(:load)
+            .with(original_url)
+            .and_yield(StringIO.new(redirect_html))
+
+          allow(downloader).to receive(:load)
+            .with(target_url)
+            .and_yield(StringIO.new(chart_html))
+
+          refresh_tag_following_downloader.load_following_refresh_tags(original_url) do |file|
+            result = file.read
+          end
+
+          expect(result).to eq(chart_html)
+        end
+
+        it 'fails on too many redirects' do
+          downloader = double(Downloader)
+          refresh_tag_following_downloader = RefreshTagFollowingDownloader.new(downloader)
+
+          original_url = 'http://datawrapper.dwcdn.net/HPKfl/2/'
+
+          redirect_html = <<-HTML
+            <html><head><meta http-equiv="REFRESH" content="0; url=#{original_url}"></head></html>
+          HTML
+
+          allow(downloader).to receive(:load).with(original_url) do |&block|
+            block.call(StringIO.new(redirect_html))
+          end
+
+          expect {
+            refresh_tag_following_downloader.load_following_refresh_tags(original_url)
+          }.to raise_error(RefreshTagFollowingDownloader::TooManyRedirects)
+        end
+
+        it 'fails on invalid refresh meta tag' do
+          downloader = double(Downloader)
+          refresh_tag_following_downloader = RefreshTagFollowingDownloader.new(downloader)
+
+          original_url = 'http://datawrapper.dwcdn.net/HPKfl/2/'
+
+          redirect_html = <<-HTML
+            <html><head><meta http-equiv="REFRESH" content="something strange"></head></html>
+          HTML
+
+          allow(downloader).to receive(:load).with(original_url).and_yield(StringIO.new(redirect_html))
+
+          expect {
+            refresh_tag_following_downloader.load_following_refresh_tags(original_url)
+          }.to raise_error(RefreshTagFollowingDownloader::NoUrlInRefreshMetaTag)
+        end
+
+        it 'fails on refresh meta tag without content attribute' do
+          downloader = double(Downloader)
+          refresh_tag_following_downloader = RefreshTagFollowingDownloader.new(downloader)
+
+          original_url = 'http://datawrapper.dwcdn.net/HPKfl/2/'
+
+          redirect_html = <<-HTML
+            <html><head><meta http-equiv="REFRESH"></head></html>
+          HTML
+
+          allow(downloader).to receive(:load).with(original_url).and_yield(StringIO.new(redirect_html))
+
+          expect {
+            refresh_tag_following_downloader.load_following_refresh_tags(original_url)
+          }.to raise_error(RefreshTagFollowingDownloader::NoUrlInRefreshMetaTag)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Datawrapper started using meta tags of the form

   <html><head><meta http-equiv="REFRESH" content="0; url=/xxx/5/"></head></html>

to redirect to the current revision of a chart. When scraping we need
to download the target url instead.

Wrap the Downloader with a decorator that looks for refresh meta tags.