### PR TITLE
Try to minimize changes in script tag order

### DIFF
--- a/lib/pageflow/chart/scraper.rb
+++ b/lib/pageflow/chart/scraper.rb
@@ -67,13 +67,18 @@ module Pageflow
       end
 
       def combine_script_tags_in_head
-        script_src_tags_in_head.each(&:remove)
+        script_tags_to_remove = script_src_tags_in_head
+        return if script_tags_to_remove.empty?
 
         all_script_src_tag = Nokogiri::XML::Node.new('script', document)
         all_script_src_tag[:src] = 'all.js'
         all_script_src_tag[:type] = 'text/javascript'
-        document.at_css('head').children.first
-                .add_previous_sibling(all_script_src_tag)
+
+        script_tags_to_remove
+          .first
+          .add_previous_sibling(all_script_src_tag)
+
+        script_tags_to_remove.each(&:remove)
       end
 
       def combine_css_link_tags

--- a/spec/pageflow/chart/scraper_spec.rb
+++ b/spec/pageflow/chart/scraper_spec.rb
@@ -37,6 +37,34 @@ module Pageflow
           expect(HtmlFragment.new(scraper.html)).to have_tag('head script[src="all.js"]')
         end
 
+        it 'inserts script tag at position of first script src tag to keep position' \
+           'between inline scripts' do
+          html = <<-HTML
+            <!DOCTYPE html>
+            <html>
+              <head>
+                <script id="setup">
+                  // Some setup required for scripts below to execute
+                </script>
+                <script type="text/javascript" src="/some.js"></script>
+                <script type="text/javascript" src="/other.js"></script>
+                <script id="usage">
+                  // Some script using stuff loading above
+                </script>
+              </head>
+              <body>
+              </body>
+            </html>
+          HTML
+          scraper = Scraper.new(html)
+
+          fragment = HtmlFragment.new(scraper.html)
+
+          expect(fragment).to have_tags_in_order('head script#setup',
+                                                 'head script[src="all.js"]',
+                                                 'head script#usage')
+        end
+
         it 'combines link tags in head' do
           html = <<-HTML
             <!DOCTYPE html>

--- a/spec/support/html_fragment.rb
+++ b/spec/support/html_fragment.rb
@@ -10,4 +10,17 @@ class HtmlFragment
   def has_tag?(selector)
     !!document.at_css(selector)
   end
+
+  def has_tags_in_order?(*selectors)
+    all_elements = document.css('*')
+
+    elements = selectors.map do |selector|
+      document.at_css(selector) ||
+        raise("Selector '#{selector}}' did not match any element.")
+    end
+
+    elements.each_cons(2).all? do |element1, element2|
+      all_elements.index(element1) < all_elements.index(element2)
+    end
+  end
 end


### PR DESCRIPTION
Some datawrapper documents have the form

    <head>
      <script>
        // Inline script with required setup for library-a
      </script>
      <script src="library-a.js></script>
      <script src="library-b.js></script>
      <script>
        // Usage of library-b
      </script>
    </head>

We need to make sure that the combined script tag is inserted between
the inline script tags. We therefore insert the combined script tag
before the first script tag with a src attribute.