### PR TITLE
ignore OpenURI::HTTPError when downloading

### DIFF
--- a/lib/pageflow/chart/downloader.rb
+++ b/lib/pageflow/chart/downloader.rb
@@ -12,12 +12,11 @@ module Pageflow
 
       def load(url)
         file = open(make_absolute(url))
-
-        begin
-          yield(file)
-        ensure
-          file.close
-        end
+        yield(file)
+      rescue OpenURI::HTTPError => exception
+        Rails.logger.error "Exception loading url #{url}: #{exception.message}"
+      ensure
+        file.close if file
       end
 
       def load_all(urls, options = {})

--- a/spec/pageflow/chart/downloader_spec.rb
+++ b/spec/pageflow/chart/downloader_spec.rb
@@ -17,6 +17,19 @@ module Pageflow
           expect(result).to eq("aaa")
         end
 
+        it 'ignores HTTP response 404' do
+          downloader = Downloader.new
+          result = ''
+
+          stub_request(:get, "http://example.com/a").to_return(status: 404, body: 'aaa')
+
+          downloader.load('http://example.com/a') do |io|
+            result = io.read
+          end
+
+          expect(result).to eq("")
+        end
+
         it 'derives protocol from base_url' do
           downloader = Downloader.new(base_url: 'http://someother.com')
           result = ''


### PR DESCRIPTION
It seems our app should not crash because of a page not found for instance.