### PR TITLE
Require Pageflow 12.1 for split layout handling

### DIFF
--- a/chart.gemspec
+++ b/chart.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_runtime_dependency 'pageflow', '~> 12.x'
+  spec.add_runtime_dependency 'pageflow', '~> 12.1'
   spec.add_runtime_dependency 'nokogiri', '~> 1.0'
   spec.add_runtime_dependency 'paperclip', '~> 4.2'
   spec.add_runtime_dependency 'state_machine', '~> 1.2'


### PR DESCRIPTION
The new `page-with_split_layout` CSS class ensures page content does
not overflow left column.