### PR TITLE
Drop direct Paperclip dependency

### DIFF
--- a/chart.gemspec
+++ b/chart.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'pageflow', '~> 13.x'
   spec.add_runtime_dependency 'nokogiri', '~> 1.0'
-  spec.add_runtime_dependency 'paperclip', '~> 4.2'
   spec.add_runtime_dependency 'pageflow-public-i18n', '~> 1.0'
 
   spec.add_development_dependency 'pageflow-support', '~> 13.x'


### PR DESCRIPTION
Let Pageflow decide which Paperclip version to use.