### PR TITLE
Turn lib into eager load path

### DIFF
--- a/lib/pageflow/chart/engine.rb
+++ b/lib/pageflow/chart/engine.rb
@@ -5,7 +5,7 @@ module Pageflow
     class Engine < Rails::Engine
       isolate_namespace Pageflow::Chart
 
-      config.autoload_paths << File.join(config.root, 'lib')
+      config.paths.add('lib', eager_load: true)
       config.assets.precompile += ['pageflow/chart/custom.css', 'pageflow/chart/transparent_background.css']
       config.i18n.load_path += Dir[config.root.join('config', 'locales', '**', '*.yml').to_s]
 


### PR DESCRIPTION
Files on the autoload path are no longer automatically available in
production.