### PR TITLE
Display original chart instead of scraped site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in chart.gemspec
 gemspec
 
-gem 'pageflow', git: 'git@gitlab.codevise.de:edge/pageflow', branch: 'paged-embed-consent'
+gem 'pageflow', git: 'git@gitlab.codevise.de:edge/pageflow', branch: 'master-65428'
 
 gem 'pageflow-support',
     git: 'git@gitlab.codevise.de:edge/pageflow',
-    branch: 'paged-embed-consent',
+    branch: 'master-65428',
     glob: 'spec/support/*.gemspec'

--- a/app/assets/javascripts/pageflow/chart.js
+++ b/app/assets/javascripts/pageflow/chart.js
@@ -1,5 +1,3 @@
-//= require jquery.simulate-events
-
 //= require_self
 //= require ./chart/asset_urls
 //= require ./chart/consent

--- a/app/assets/javascripts/pageflow/chart/editor/views/configuration_editor.js
+++ b/app/assets/javascripts/pageflow/chart/editor/views/configuration_editor.js
@@ -7,14 +7,13 @@ pageflow.ConfigurationEditorView.register('chart', {
     });
 
     this.tab('files', function() {
-      this.input('scraped_site_id', pageflow.chart.ScrapedUrlInputView, {
-        supportedHosts: supportedHosts,
+      this.input('chart_url', pageflow.UrlInputView, {
         displayPropertyName: 'display_scraped_site_url',
-        required: true
+        supportedHosts: supportedHosts,
+        required: true,
+        permitHttps: true
       });
-      this.input('scraped_site_id', pageflow.FileProcessingStateDisplayView, {
-        collection: 'pageflow_chart_scraped_sites'
-      });
+
       this.view(pageflow.chart.DatawrapperAdView);
       this.input('full_width', pageflow.CheckBoxInputView);
       this.group('background');

--- a/app/assets/javascripts/pageflow/chart/editor/views/embedded/iframe_embedded_view.js
+++ b/app/assets/javascripts/pageflow/chart/editor/views/embedded/iframe_embedded_view.js
@@ -4,14 +4,29 @@ pageflow.chart.IframeEmbeddedView = Backbone.Marionette.View.extend({
   },
 
   render: function() {
-    this.updateScrapedSite();
+    if (this.model.has('chart_url')) {
+      this.updateChartUrl();
+    }
+    else if (this.model.has('scraped_site_id')) {
+      this.updateScrapedSite();
+    }
+
     return this;
   },
 
   update: function() {
-    if (this.model.hasChanged(this.options.propertyName)) {
+    if (this.model.hasChanged('chart_url')) {
+      this.updateChartUrl();
+    }
+    else if (this.model.hasChanged('scraped_site_id')) {
       this.updateScrapedSite();
     }
+  },
+
+  updateChartUrl: function() {
+    this.$el.attr('src', this.model.get('chart_url'));
+    this.$el.removeAttr('data-use-custom-theme');
+    this.$el.removeAttr('data-customize-layout');
   },
 
   updateScrapedSite: function() {
@@ -19,7 +34,7 @@ pageflow.chart.IframeEmbeddedView = Backbone.Marionette.View.extend({
       this.stopListening(this.scrapedSite);
     }
 
-    this.scrapedSite = this.model.getReference(this.options.propertyName,
+    this.scrapedSite = this.model.getReference('scraped_site_id',
                                                'pageflow_chart_scraped_sites');
     this.updateAttributes();
 
@@ -33,6 +48,7 @@ pageflow.chart.IframeEmbeddedView = Backbone.Marionette.View.extend({
 
     if (scrapedSite && scrapedSite.isReady()) {
       this.$el.attr('src', scrapedSite.get('html_file_url'));
+      this.$el.attr('data-customize-layout', 'true');
 
       if (scrapedSite.get('use_custom_theme')) {
         this.$el.attr('data-use-custom-theme', 'true');

--- a/app/assets/javascripts/pageflow/chart/page_type.js
+++ b/app/assets/javascripts/pageflow/chart/page_type.js
@@ -91,49 +91,6 @@ pageflow.react.registerPageTypeWithDefaultBackground('chart', _.extend({
     head.append('<link rel="stylesheet" type="text/css" href="' + path + '">');
   },
 
-  _initEventSimulation: function(element, iframe, wrapper) {
-    element.on('click', function(event) {
-      var contentElement = iframe.contents()[0];
-
-      element.css('display', 'none');
-
-      if (contentElement && event) {
-        var offset = iframe.offset();
-        var options = $.extend({}, event, {
-          screenX: event.screenX - offset.left,
-          screenY: event.screenY - offset.top,
-          clientX: event.clientX - offset.left,
-          clientY: event.clientY - offset.top,
-        });
-
-        var lastElement = $(contentElement.elementFromPoint(event.pageX - offset.left,
-                                                            event.pageY - offset.top));
-
-        lastElement.simulate('mousedown', options);
-        lastElement.simulate('mousemove', options);
-        lastElement.simulate('click', options);
-        lastElement.simulate('mouseup', options);
-
-        element.css('cursor', lastElement.css('cursor'));
-      }
-
-      element.css('display', 'block');
-
-      event.preventDefault();
-      event.stopPropagation();
-    });
-
-    iframe.load(function() {
-      iframe.contents().find('*').on('mousemove', function() {
-        wrapper.addClass('hovering');
-      });
-
-      iframe.contents().on('mouseout', function() {
-        wrapper.removeClass('hovering');
-      });
-    });
-  },
-
   prepare: function(pageElement, configuration) {
     this._loadIframe(pageElement);
   },
@@ -142,7 +99,6 @@ pageflow.react.registerPageTypeWithDefaultBackground('chart', _.extend({
     this._loadIframe(pageElement);
     this.resize(pageElement, configuration);
     this.customizeLayout(pageElement, configuration);
-    this._initEventSimulation(pageElement.find('.iframe_overlay'), pageElement.find('iframe'), pageElement.find('.iframeWrapper'));
   },
 
   activated: function(pageElement, configuration) {},

--- a/app/assets/javascripts/pageflow/chart/page_type.js
+++ b/app/assets/javascripts/pageflow/chart/page_type.js
@@ -52,9 +52,11 @@ pageflow.react.registerPageTypeWithDefaultBackground('chart', _.extend({
     var that = this;
     var iframe = pageElement.find('iframe');
     var scroller = pageElement.find('.scroller');
-    var iframeOverlay = pageElement.find('.iframe_overlay');
 
-    if(!this.layoutCustomized) {
+    if (!iframe.data('customizeLayout')) {
+      pageElement.find('.iframeWrapper').addClass('active');
+    }
+    else if(!this.layoutCustomized) {
       iframe.load(function() {
         $(this).contents().find('.fs-btn').css('display','none');
         $(this).contents().find('body').addClass($("[data-theme]").attr('data-theme'));
@@ -126,8 +128,7 @@ pageflow.react.registerPageTypeWithDefaultBackground('chart', _.extend({
   embeddedEditorViews: function() {
     return {
       'iframe': {
-        view: pageflow.chart.IframeEmbeddedView,
-        options: {propertyName: 'scraped_site_id'}
+        view: pageflow.chart.IframeEmbeddedView
       }
     };
   },

--- a/app/assets/stylesheets/pageflow/chart.scss
+++ b/app/assets/stylesheets/pageflow/chart.scss
@@ -97,12 +97,11 @@
     .bigScreen & {
       position: absolute;
       width: 86% !important;
-      height: 87%;
       top: 10%;
       left: 5% !important;
       z-index: 201;
       margin-top: 0 !important;
-      max-height: none !important;
+      max-height: 84% !important;
 
       .bigscreen_toggler {
         background-position: -25px 0;

--- a/app/assets/stylesheets/pageflow/chart.scss
+++ b/app/assets/stylesheets/pageflow/chart.scss
@@ -62,18 +62,6 @@
       }
     }
 
-    .iframe_overlay {
-      .has_mobile_platform & {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        pointer-events: all;
-        background-color: transparent;
-      }
-    }
-
     .text_position_right &.widescreened {
       @include position-end(auto);
       @include position-start(8%);
@@ -102,7 +90,7 @@
       }
     }
 
-    &:hover .bigscreen_toggler, &.hovering .bigscreen_toggler {
+    &:hover .bigscreen_toggler {
       opacity: 1;
     }
 

--- a/app/helpers/pageflow/chart/scraped_sites_helper.rb
+++ b/app/helpers/pageflow/chart/scraped_sites_helper.rb
@@ -1,6 +1,8 @@
 module Pageflow
   module Chart
     module ScrapedSitesHelper
+      include RevisionFileHelper
+
       IFRAME_ATTRIBUTES = {
         style: 'width: 100%; height: 100%',
         scrolling: 'auto',
@@ -11,21 +13,28 @@ module Pageflow
         webkitallowfullscreen: 'true'
       }
 
-      def scraped_site_iframe(scraped_site_id)
-        scraped_site = find_file_in_entry(ScrapedSite, scraped_site_id)
+      def scraped_site_iframe(configuration)
         data_attributes = {}
 
-        if scraped_site
+        if configuration['chart_url']
           data_attributes = {
-            src: scraped_site.html_file_url
+            src: configuration['chart_url']
           }
-
-          if scraped_site.use_custom_theme
-            data_attributes[:use_custom_theme] = true
-          end
+        elsif (scraped_site = find_scraped_site(configuration))
+          data_attributes = {
+            src: scraped_site.html_file_url,
+            customize_layout: true,
+            use_custom_theme: scraped_site.use_custom_theme ? true : nil
+          }
         end
 
         content_tag(:iframe, '', IFRAME_ATTRIBUTES.merge(data: data_attributes))
+      end
+
+      private
+
+      def find_scraped_site(configuration)
+        find_file_in_entry(ScrapedSite, configuration['scraped_site_id'])
       end
     end
   end

--- a/app/views/pageflow/chart/page.html.erb
+++ b/app/views/pageflow/chart/page.html.erb
@@ -7,7 +7,7 @@
 
   <div class="content">
     <div class="iframeWrapper">
-      <%= scraped_site_iframe(configuration['scraped_site_id']) %>
+      <%= scraped_site_iframe(configuration) %>
       <%= third_party_embed_opt_in(
             entry: entry,
             vendor_name: 'datawrapper',

--- a/app/views/pageflow/chart/page.html.erb
+++ b/app/views/pageflow/chart/page.html.erb
@@ -13,7 +13,6 @@
             vendor_name: 'datawrapper',
             message: t('pageflow.public.chart.opt_in_prompt')
           ) %>
-      <div class="iframe_overlay"></div>
       <div class="bigscreen_toggler" tabindex="4" title="<%= t('pageflow.public.chart.toggle') %>"><%= t('pageflow.public.chart.toggle') %></div>
       <div class="opt_out_wrapper">
         <%= third_party_embed_opt_out_info(entry) %>

--- a/config/locales/new/chart_url.de.yml
+++ b/config/locales/new/chart_url.de.yml
@@ -1,0 +1,6 @@
+de:
+  pageflow:
+    chart:
+      page_attributes:
+        chart_url:
+          label: Diagramm URL

--- a/config/locales/new/chart_url.en.yml
+++ b/config/locales/new/chart_url.en.yml
@@ -1,0 +1,6 @@
+en:
+  pageflow:
+    chart:
+      page_attributes:
+        chart_url:
+          label: Chart URL

--- a/lib/pageflow/chart/configuration.rb
+++ b/lib/pageflow/chart/configuration.rb
@@ -64,9 +64,10 @@ module Pageflow
         @paperclip_base_path = ':pageflow_s3_root'
         @scraped_sites_root_url = nil
         @supported_hosts = [
-          'http://cf.datawrapper.de',
-          'http://datawrapper.dwcdn.de',
-          'http://datawrapper.dwcdn.net'
+          'cf.datawrapper.de',
+          'charts.datawrapper.de',
+          'datawrapper.dwcdn.de',
+          'datawrapper.dwcdn.net'
         ]
         @use_custom_theme = false
         @datawrapper_themes_with_transparent_background_support = ['pageflow']

--- a/spec/helpers/pageflow/chart/scraped_sites_helper_spec.rb
+++ b/spec/helpers/pageflow/chart/scraped_sites_helper_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+require 'pageflow/used_file_test_helper'
+
+module Pageflow
+  module Chart
+    describe ScrapedSitesHelper do
+      include UsedFileTestHelper
+
+      before { Pageflow::Chart.config.use_custom_theme = false }
+
+      it 'renders iframe with data-src attribute for scraped site' do
+        scraped_site = create_used_file(:scraped_site, :processed)
+
+        html = scraped_site_iframe('scraped_site_id' => scraped_site.perma_id)
+
+        iframe = Capybara.string(html).find('iframe')
+        expect(iframe['data-src']).to match(%r{original/index\.html})
+      end
+
+      it 'renders no data-custom-theme attribute by default' do
+        scraped_site = create_used_file(:scraped_site, :processed)
+
+        html = scraped_site_iframe('scraped_site_id' => scraped_site.perma_id)
+
+        iframe = Capybara.string(html).find('iframe')
+        expect(iframe['data-use-custom-theme']).to be_blank
+        expect(iframe['data-customize-layout']).to eq('true')
+      end
+
+      it 'renders data-custom-theme if site has custom theme' do
+        Pageflow::Chart.config.use_custom_theme = true
+        scraped_site = create_used_file(:scraped_site, :processed)
+
+        html = scraped_site_iframe('scraped_site_id' => scraped_site.perma_id)
+
+        iframe = Capybara.string(html).find('iframe')
+        expect(iframe['data-use-custom-theme']).to eq('true')
+        expect(iframe['data-customize-layout']).to eq('true')
+      end
+
+      it 'renders iframe with data-src attribute for chart_url' do
+        html = scraped_site_iframe('chart_url' => 'https://example.com/chart')
+
+        iframe = Capybara.string(html).find('iframe')
+        expect(iframe['data-src']).to eq('https://example.com/chart')
+      end
+
+      it 'renders no data-custom-theme attribute for chart_url' do
+        html = scraped_site_iframe('chart_url' => 'https://example.com/chart')
+
+        iframe = Capybara.string(html).find('iframe')
+
+        expect(iframe['data-customize-layout']).to be_blank
+        expect(iframe['data-use-custom-theme']).to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since charts have become much more complex, with dynamically loaded
polyfills and JSON data, scraping the charts no longer works reliably.

We used scraped sites as a way to serve iframes from same origin to be able
to:

1. Inject custom styles

2. Simulate events

Datawrapper has been providing a custom Pageflow theme for a long time. The
only modification, we did was trying to make the background transparent.
This also no longer works with current charts.

Simulating events does not work well for more complex interactions like
pan/zoom.

For new chart urls simply display the original chart in the iframe.

REDMINE-19000